### PR TITLE
Fix bug that VAdmitted and VVNotSupported become VUnknown

### DIFF
--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -379,11 +379,12 @@ object LLVMBerryLogics {
 
   def classifyValidateResult(x: (Int, String, String)): VResult = {
     def f(y: String) = x._2.split('\n').last.contains(y)
-    def g(y: String) = x._3.split('\n').head.contains(y)
+    def g(y: String) = x._3.split('\n').last.contains(y)
+    def h(y: String) = x._2.split('\n').head.contains(y)
 
     if(f("Validation failed.")) VFail
     else if(f("Validation succeeded.")) VSuccess
-    else if(f("Set to admitted.")) VAdmitted
+    else if(h("Set to admitted.")) VAdmitted
     else if(f("Set to fail.")) VAssertionFail
     else if(g("Fatal error: exception Failure") &&
       (g("Not_Supported") || g("is not supported for now."))) VNotSupported


### PR DESCRIPTION
제가 스칼라 문법을 몰라서 기존 함수를 보고 맞춰서 만들었습니다. 일단 401.bzip2를 돌렸을때 나오는 unknown은 다시 admit과 not supported로 바뀝니다. 제가 바꾼점이 타당한지 확인 부탁드립니다.

아까 no-separate에 잘못 보내서 이쪽으로 다시 보냅니다.