### PR TITLE
Let generating report.validate use StringBuilder

### DIFF
--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -825,14 +825,18 @@ class TestRunner(
   def VQR_to_list: String = {
     if(llvmberry_logics.report_nosuccess) {
       VQJobResult.columnNames + "\n" +
-      VQR.foldLeft("")((s, i) => s +
-        (if(i.classifiedResult == LLVMBerryLogics.VSuccess) i.toString + "\n"
-        else "")
-      )
+      VQR.foldLeft(StringBuilder.newBuilder)((sbldr, i) =>
+        if(i.classifiedResult == LLVMBerryLogics.VSuccess)
+          sbldr.append(i.toString).append("\n")
+        else
+          sbldr
+      ).toString
     }
     else {
       VQJobResult.columnNames + "\n" +
-      VQR.foldLeft("")((s, i) => s + i.toString + "\n")
+      VQR.foldLeft(StringBuilder.newBuilder)((sbldr, i) =>
+        sbldr.append(i.toString).append("\n")
+      ).toString()
     }
   }
 


### PR DESCRIPTION
This reduces time complexity  from O(n^2) to O(n) (where n is the # of concatenated operations)

http://www.pellegrino.link/2015/08/22/string-concatenation-with-java-8.html

